### PR TITLE
Address CVE-2021-44228 (log4j2 vulnerability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog of qflow versions
+
+## 1.0.1 (2021-12-13)
+
+Addresses CVE-2021-44228
+
+### Dependencies
+
+* `org.apache.logging.log4j:log4j-core` 2.2.0 -> 2.15.0
+* `org.apache.logging.log4j:log4j-api` 2.2.0 -> 2.15.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>life.qbic</groupId>
 	<artifactId>qFlow</artifactId>
-	<version>1.0</version>
+	<version>1.0.1</version>
 	<name>qFlow</name>
 
 	<properties>
@@ -166,13 +166,13 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.2</version>
+			<version>2.15.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.2</version>
+			<version>2.15.0</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
This hotfix addresses the CVE-2021-44228 by 
updating the log4j2 dependencies to 2.15.0.